### PR TITLE
iPad Pro、iPad、iPhone 6/7/8対応のレスポンシブデザインを設定

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -76,3 +76,76 @@ table {
 body{
   background-color: rgb(243, 243, 234)
 }
+
+/* iPad Pro対応 */
+@media (max-width: 1024px) {
+	.dummy{
+		width: 350px;
+	}
+}
+
+/* iPad 対応 */
+@media (max-width: 768px) {
+	.dummy{
+		width: 120px;
+		font-size: 10px;
+	}
+}
+
+/* iPhone 6/7/8対応 */
+@media (max-width: 375px) {
+	/* ヘッダー部 */
+	.header-title{
+		font-size: 1rem;
+	}
+	.title_description{
+		font-size: 2px;
+		padding: 5px 15px 0 0;
+	}
+	.dummy{
+		width: 10px;
+	}
+	.lists-right{
+		padding-top: 10px;
+		font-size: 0.5rem;
+	}
+	.user-nickname {
+		margin-right: 1vw;
+	}
+	.login {
+		margin-right: 1vw;
+	}
+/* アプリ広告部 */
+	.title-contents{
+		padding: 10px;
+	}
+	.service-title {
+		font-size: 15px;
+	}
+	.service-explain{
+		font-size: 10px;
+	}
+	.genre-select-label{
+		font-size: 12px;
+	}
+	/* ネオン文字部 */
+	.neon{
+		font-size: 10px;
+	}
+
+	/* 課題作成ボタン */
+	.new-question-btn {
+		width: 80px;
+		border-radius: 15%;
+		bottom: 10px;
+		right: 10px;
+		padding: 5px;
+	}
+	.new-question-btn-text {
+		font-size: 12px;
+	}
+	.new-question-btn-icon {
+		width: 30%;
+		height: 30%;
+	}
+}

--- a/app/assets/stylesheets/questions/index.scss
+++ b/app/assets/stylesheets/questions/index.scss
@@ -1,6 +1,3 @@
-.main{
-  background-color: rgb(239, 240, 220);
-}
 .title-contents {
 background-image: image-url('6yGcWWt6WaIF1aw1625735467_1625735650');
 background-size: 100% 100%;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <title>SppApp</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <%= Gon::Base.render_data %>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>


### PR DESCRIPTION
#What
iPad Pro、iPad、iPhone 6/7/8対応のレスポンシブデザインを設定

#Why
ペルソナはPC操作をする機会が少ないと想定したため、
操作する機会の多い端末向けにレスポンシブ化する事で操作性の向上と離脱性を抑制を狙いたい