### PR TITLE
新規登録、ログイン機能をより使いやすくする為の編集

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -202,7 +202,10 @@ body{
 	.neon{
 		font-size: 10px;
 	}
-
+	/* 新規登録ページ */
+	.registrations-new-page{
+		font-size: 12px;
+	}
 	/* 課題作成ボタン */
 	.new-question-btn {
 		width: 80px;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -134,7 +134,7 @@ body{
 	}
 	.dummy{
 		width: 120px;
-		font-size: 10px;
+		font-size: 12px;
 	}
 	/* マイページ部 */
 	.table{

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -206,6 +206,10 @@ body{
 	.registrations-new-page{
 		font-size: 12px;
 	}
+	/* ログインページ */
+	.sessions-new-page{
+		font-size: 12px;
+	}
 	/* 課題作成ボタン */
 	.new-question-btn {
 		width: 80px;

--- a/app/javascript/answer_timer.js
+++ b/app/javascript/answer_timer.js
@@ -16,7 +16,7 @@ function countdowntimer(){
     countdownEL.innerHTML = `残り時間${minites}分${seconds}秒`;
     time--;
     if (time === 0) {
-    alert('じかんです!よくばんばりました✨ きょうかしょを見るか、大人の人に聞いてみてね^^');
+    alert('じかんです!よくばんばりました✨\nきょうかしょをみるか、おとなのひとにきいてみてね^^');
     clearInterval(timerID);
     };
   };

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,47 +1,48 @@
 <%= render "shared/header" %>
 <div class="registrations-new-page">
-  <h2>Sign up</h2>
-  <h2>( しんきとうろく がめんだよ )</h2><br />
+  <h2>新規登録ページ</h2>
+  <h2>(しんきとうろく がめんだよ)</h2>
+  <span><em>おうちのひとと、そうだんしながらはじめてね</em></span>
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %><br />
 
     <div class="field">
-      <%= f.label :nickname %><br />
-      <div class="nickname-description">( ニックネームをきめてね )</div>
-      <%= f.text_field :nickname, autofocus: true, autocomplete: "nickname" %>
+      <%= f.label :ニックネーム %><br />
+      <div class="nickname-description">(ニックネームはアプリのなかで、つかえるなまえだよ)</div>
+      <%= f.text_field :nickname, autofocus: true, autocomplete: "nickname", placeholder:"例) test太郎" %>
     </div><br />
 
     <div class="field">
-      <%= f.label :email %><br />
-      <div class="email-description">( メールアドレスをにゅうりょくしてね )</div>
-      <%= f.email_field :email, autocomplete: "email" %>
+      <%= f.label :メールアドレス %><br />
+      <div class="email-description">(メールアドレスは、てきとうなものでもいいよ)</div>
+      <%= f.email_field :email, autocomplete: "email", placeholder:"例) test@test.com" %>
     </div><br />
 
     <div class="field">
-      <%= f.label :password %>
+      <%= f.label :パスワード %>
           <div class="password-description"></div>
       <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em>
+      <em>(<%= @minimum_password_length %>もじいじょう、ひつようだよ)</em>
       <% end %><br />
       <div class="password-description">
-      ( パスワードをきめてね。 少なくても、6もじはひつようだよ )
+      (パスワードはわすれないものにしようね)
       </div>
-      <%= f.password_field :password, autocomplete: "new-password" %>
+      <%= f.password_field :password, autocomplete: "new-password", placeholder:"例) 20150707" %>
     </div><br />
 
     <div class="field">
-      <%= f.label :password_confirmation %><br />
+      <%= f.label :パスワードのかくにん%><br />
       <div class="password-confirmation-description">
       ( パスワードをかくにんするよ。 おなじパスワードをもういちど、にゅうりょくしてね )
       </div>
-      <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder:"例) 20150707" %>
     </div><br />
 
     <div class="actions">
       <div class="sign-up-description">
-      ( とうろくするよ。 ↓のSign upボタンを押してね )
+      (↓のとうろくして あそぶボタンをポチしてね)
       </div>
-      <%= f.submit "Sign up" %>
+      <%= f.submit "とうろくして あそぶ" %>
     </div>
   <% end %>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -33,7 +33,7 @@
     <div class="field">
       <%= f.label :パスワードのかくにん%><br />
       <div class="password-confirmation-description">
-      ( パスワードをかくにんするよ。 おなじパスワードをもういちど、にゅうりょくしてね )
+      ( パスワードをかくにんするよ。<br> おなじパスワードをもういちど、にゅうりょくしてね )
       </div>
       <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder:"例) 20150707" %>
     </div><br />

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,19 +1,20 @@
 <%= render "shared/header" %>
 <div class="sessions-new-page">
-  <h2>Log in</h2>
-  <h2>( ログイン がめんだよ )</h2><br />
+  <h2>ログインページ</h2>
+  <h2>(ログイン がめんだよ)</h2>
+  <span><em>わからないときは、おうちのひとにきこうね</em></span>
 
   <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-    <div class="field">
-      <%= f.label :email %><br />
-      <div class="email-description">( メールアドレスをにゅうりょくしてね )</div>
+    <div class="field"><br/>
+      <%= f.label :メールアドレス %><br />
+      <div class="email-description">(とうろくしたメールアドレスをにゅうりょくしてね)</div>
       <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
     </div><br />
 
     <div class="field">
-      <%= f.label :password %><br />
+      <%= f.label :パスワード %><br />
       <div class="password-description">
-      ( パスワードをおもいだして、にゅうりょくしてね )
+      (パスワードをおもいだして、にゅうりょくしてね)
       </div>
       <%= f.password_field :password, autocomplete: "current-password" %>
     </div><br />
@@ -23,9 +24,9 @@
       ( さぁ、ログインしてあそぼう！)
       </div>
       <div class="sign-up-description">
-      (↓Log inのボタンをおしてね )
+      (↓ログインしてあそぶボタンをおしてね )
       </div>
-      <%= f.submit "Log in" %>
+      <%= f.submit "ログインしてあそぶ" %>
     </div>
   <% end %>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -24,6 +24,16 @@
       <% else %>
       <li><%= link_to 'ログイン', new_user_session_path, class: "login" %></li>
       <li><%= link_to '新規登録', new_user_registration_path, class: "sign-up" %></li>
+      <script>
+        function guide() {
+          var fn = function() {
+            confirm("やりかたがわからないかな？\nはじめてのときは、しんきとうろくをしてね！\nまえにきたことがあるときは、ログインをしてあそんでね。\nおうちのひとにきいてみよう！");
+          };
+          var tm = 20000;
+          setTimeout(fn,tm);
+        };
+        window.addEventListener('load', guide)
+      </script>
       <% end %>
     </div>
       <%#ログインの有無で表示が変わる条件分岐%>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -38,7 +38,7 @@ en:
       updated_not_active: "Your password has been changed successfully."
     registrations:
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
-      signed_up: "ようこそ！とうろくしてくれてありがとうございます"
+      signed_up: "もんだいにチャレンジできます！"
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."


### PR DESCRIPTION
# What
未ログイン状態で一定時間経過した場合の案内設定を追加し、新規登録・ログイン機能を使いやすくする為、ビューの編集を実施

# Why
ペルソナはPC操作に慣れておらず、かつ初めに何をすれば良いのか分からなくなると想定した為
また、新規登録・ログインページには英語や漢字が含まれており、アプリに苦手意識を抱いてしまう事で離脱率を上げてしまう恐れがあった為