### PR TITLE
レスポンスレイアウトの微修正

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -77,6 +77,24 @@ body{
   background-color: rgb(243, 243, 234)
 }
 
+@media (max-width: 1362px) {
+	/* ヘッダー部 */
+	.title_description{
+		padding: 10px 0 0 0;
+	}
+	.dummy{
+		width: 530px;
+	}
+}
+@media (max-width: 1162px) {
+	/* ヘッダー部 */
+/* .title_description{
+	padding: 10px 0 0 0;
+} */
+	.dummy{
+		width: 400px;
+	}
+}
 /* iPad Pro対応 */
 @media (max-width: 1024px) {
 	/* ヘッダー部 */

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -288,6 +288,9 @@ body{
 	.question-title{
 		list-style: none;
 	}
+	.genre---li{
+		font-size: 10px;
+	}
 	.genre-tip{
 		margin-left: 0;
 		font-size: 10px;

--- a/app/assets/stylesheets/questions/genre.css
+++ b/app/assets/stylesheets/questions/genre.css
@@ -12,6 +12,10 @@
   margin-top: 10px;
   list-style-type: circle;
 }
+.genre---li{
+  color: darkgray;
+  font-size: 12px;
+}
 
 .genre-question-name{
   text-decoration: none;

--- a/app/views/questions/genre.html.erb
+++ b/app/views/questions/genre.html.erb
@@ -10,8 +10,12 @@
   <div class="genre-list">
     <% if @results.length !=0 %>
       <% @results.each do |result| %>
+        
         <div class="question-title" >
           <li class="genre-li">
+          <% if @p.genre_id_eq.blank? %>
+            <span class="genre---li"><%= "《#{result.genre.name}》" %></span>
+          <% end %>
           <%= link_to result.question_name, new_question_answer_path(question_id: result.id ) ,class: "genre-question-name", id: "button" %>
           <%# 出題者のみ編集・削除機能を表示する条件分岐 %>
           <% if user_signed_in? %>

--- a/app/views/users/_answer.html.erb
+++ b/app/views/users/_answer.html.erb
@@ -1,7 +1,7 @@
 <div class="my-page-score">
   <span class="answer-question-id">
-    <%= "【#{answer.question.genre.name}"%>
-    <%= " No.#{answer.question.id}】"%>
+    <%= "【#{answer.question.genre.name}】"%>
+    <%= " 《 No.#{answer.question.id} 》"%>
   </span>
   <span>
     <% if answer.score.present?%>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -102,7 +102,7 @@ ja:
         we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
       new:
         sign_up: アカウント登録
-      signed_up: アカウント登録が完了しました。
+      signed_up: もんだいにチャレンジできます
       signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
       signed_up_but_locked: アカウントがロックされているためログインできません。
       signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。


### PR DESCRIPTION
# What
レスポンスレイアウトの微修正

# Why
・初期課題の追加により、全問題が表示された際に教科目が分かりづらい
・マイページの科目表示に違和感がある
というユーザーの声を参考に修正
また、ipadでの横向き表示の際に一部レイアウトが崩れる状態を確認した為、追加でレスポンシブデザインの追加で対応